### PR TITLE
nodeのバージョンを22系に指定

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=22.0.0"
+    "node": "22.x"
   },
   "overrides": {
     "postcss": "^8.5.16"


### PR DESCRIPTION
## 概要
デプロイ時にnodejsの警告が出るため、解消用にバージョンを固定